### PR TITLE
Revert pymemcached 3.3.0 for broken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ flake8==5.0.4
 isort==5.10.1
 mock==4.0.3
 nose==1.3.7
-pymemcache==3.5.2
+pymemcache==3.3.0
 readme-renderer==37.0


### PR DESCRIPTION
Currently newest pymecached was broken.
https://github.com/harikitech/django-elastipymemcache/runs/7992426622?check_suite_focus=true

So, revert to 3.3.0.

We should update 3.5.2 to another PR.